### PR TITLE
Add null check for email validation in EditSettings page

### DIFF
--- a/yafsrc/YetAnotherForum.NET/Pages/Profile/EditSettings.cshtml.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/Profile/EditSettings.cshtml.cs
@@ -1,5 +1,5 @@
 /* Yet Another Forum.NET
- * Copyright (C) 2003-2005 Bjørnar Henden
+ * Copyright (C) 2003-2005 Bjï¿½rnar Henden
  * Copyright (C) 2006-2013 Jaben Cargman
  * Copyright (C) 2014-2025 Ingo Herbote
  * https://www.yetanotherforum.net/
@@ -155,7 +155,7 @@ public class EditSettingsModel : ProfilePage
     /// </summary>
     public async Task<IActionResult> OnPostAsync()
     {
-        if (this.Email != this.PageBoardContext.PageUser.Email)
+        if (this.Email != null && this.Email != this.PageBoardContext.PageUser.Email)
         {
             var newEmail = this.Email.Trim();
 


### PR DESCRIPTION
## 📝 Description

This PR adds a check for missing email verification value on the edit settings page to prevent possible errors at runtime when the email field is empty or undefined.

## 🔧 Changes have been made

- Added a check for missing values for the email field before processing
- Improved error handling in the email verification logic


## 🐛 Problem solved

Previously, when email modification was prohibited in the settings, email verification could lead to errors when trying to verify null or undefined email values, which could lead to a crash of the editing settings page or unexpected behavior.

## , Testing

- [ ] Tested with an empty email field
- [ ] Was tested with an email value of zero
- [ ] Tested with valid email addresses
- [ ] It has been verified that the existing functionality remains unchanged.

## 📋 Type of change

- [x] Bug fixed (permanent change fixing the issue)